### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/ocrmypdf_runner.py
+++ b/ocrmypdf_runner.py
@@ -12,12 +12,12 @@ def getConfig(user):
     config = {
         "in": "/data/smb/public/ocrmypdf/in/",
         "out": "/data/smb/public/ocrmypdf/out/",
-        #"in": "/data/smb/thomas-priv/ocrmypdf/in/"
-        #if user == "thomas"
-        #else "/data/smb/andi-priv/ocrmypdf/in/",
-        #"out": "/data/smb/thomas-priv/ocrmypdf/out/"
-        #if user == "thomas"
-        #else "/data/smb/thomas-priv/ocrmypdf/out/",
+        # "in": "/data/smb/thomas-priv/ocrmypdf/in/"
+        # if user == "thomas"
+        # else "/data/smb/andi-priv/ocrmypdf/in/",
+        # "out": "/data/smb/thomas-priv/ocrmypdf/out/"
+        # if user == "thomas"
+        # else "/data/smb/thomas-priv/ocrmypdf/out/",
         "extensions": "pdf,jpg,jpeg,tif,tiff,png,gif",
         "binary": "ocrmypdf",  # needs ocrmypdf installed in path!
         "parameters": "-l deu --rotate-pages --output-type pdf --skip-text",


### PR DESCRIPTION
There appear to be some python formatting errors in fd9369829e18a95deb20350a874699261bfe4fda. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.